### PR TITLE
SIGPIPE SOCKS crash Fix #17

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -825,8 +825,11 @@ int handle_connection_write(struct connection_node *cur_connection_node){
 
 		if(retval == -1){
 			if(errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK){
-				report_error("handle_connection_write(): write(%d, %lx, %d): %s", \
+				
+				if (errno != EPIPE){
+					report_error("handle_connection_write(): write(%d, %lx, %d): %s", \
 						io->local_out_fd, (unsigned long) tmp_message->data, tmp_message->data_len, strerror(errno));
+				}
 
 				if(handle_send_dt_connection_ht_destroy(cur_connection_node->origin, cur_connection_node->id, 0) == -1){
 					report_error("handle_connection_write(): handle_send_dt_connection_ht_destroy(%d, %d, 0): %s", cur_connection_node->origin, cur_connection_node->id, strerror(errno));

--- a/revsh.c
+++ b/revsh.c
@@ -619,6 +619,11 @@ int main(int argc, char **argv){
 		}
 	}
 
+	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+		report_error("main(): signal(SIGPIPE, SIG_IGN): %s", strerror(errno));
+		return(-1);
+	}
+	
 	// We will occasionally fork() children in certain conditions. We will never handle them directly.
 	if(signal(SIGCHLD, SIG_IGN) == SIG_ERR){
 		report_error("main(): signal(SIGCHLD, SIG_IGN): %s", strerror(errno));


### PR DESCRIPTION
Ignoring Signal SIGPIPE will fix this crash
This usually happens when you write to a socket already closed on the other end (client) side
The client program (browser using the SOCKS) doesn't wait till all the data from the server is received and simply closes the socket which crashes controller if SIGPIPE is not handled.