### PR TITLE
Non-Fatal error for non-revsh connection

### DIFF
--- a/control.c
+++ b/control.c
@@ -33,7 +33,7 @@ int do_control(){
 	/* Set up the network connection. */
 	if((retval = init_io_control(config)) == -1){
 		report_error("do_control(): init_io_control(%lx): %s", (unsigned long) config, strerror(errno));
-		return(-1);
+		return(-2);
 	}
 
   // retval == -2  means control in bindshell + keepalive mode and we need to return to handle another connection.  


### PR DESCRIPTION
This should be a non-fatal error so we don't crash if revsh port got a connection from anywhere without certificates and fingerprints
Maybe this needs a better OpenSSL specific handling in init_io_control() ?