### PR TITLE
Update on Readme.md & INSTALL - for GCC & openssl compatibility

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Download OpenSSL source.
-git clone https://github.com/openssl/openssl.git
+git clone -branch OpenSSL_1_1_0-stable https://github.com/openssl/openssl.git
 cd openssl/
 
 # Configure OpenSSL to be used in building static applications.

--- a/INSTALL
+++ b/INSTALL
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Download OpenSSL source.
-git clone -branch OpenSSL_1_1_0-stable https://github.com/openssl/openssl.git
+git clone --branch OpenSSL_1_1_0-stable https://github.com/openssl/openssl.git
 cd openssl/
 
 # Configure OpenSSL to be used in building static applications.

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ MAN_DIR = /usr/share/man/man1/
 ########################################################################################################################
 
 ## Linux w/static libraries. (Full static build.)
-CFLAGS = -static -Wall -Wextra -std=c99 -pedantic -Os -DOPENSSL -I$(OPENSSL_DIR)/include
+CFLAGS = -static -Wall -Wextra -std=c99 -pedantic -Os -DOPENSSL -I$(OPENSSL_DIR)/include -fcommon
 STATIC_LIBS = $(OPENSSL_DIR)/libssl.a $(OPENSSL_DIR)/libcrypto.a
 LIBS = 
 KEYS_DIR = keys

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ _revsh_ was developed on x86_64 Linux. Here is a brief list of Arch / OS combina
 
 First, you will need to build OpenSSL from source. (See __NOTE__ below.)
 
-	git clone https://github.com/openssl/openssl.git
+	git clone -branch OpenSSL_1_1_0-stable https://github.com/openssl/openssl.git
 	cd openssl/
 	./config no-shared -static	# These options are needed to build static applications against OpenSSL.
 	make && make test	# We skip "make install" so we don't conflict with your systems default OpenSSL. We will build _revsh_ against the OpenSSL we just compiled in this tree.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ _revsh_ was developed on x86_64 Linux. Here is a brief list of Arch / OS combina
 
 First, you will need to build OpenSSL from source. (See __NOTE__ below.)
 
-	git clone -branch OpenSSL_1_1_0-stable https://github.com/openssl/openssl.git
+	git clone --branch OpenSSL_1_1_0-stable https://github.com/openssl/openssl.git
 	cd openssl/
 	./config no-shared -static	# These options are needed to build static applications against OpenSSL.
 	make && make test	# We skip "make install" so we don't conflict with your systems default OpenSSL. We will build _revsh_ against the OpenSSL we just compiled in this tree.


### PR DESCRIPTION
Changes 1 -
Modified INSTALL to git clone from openSSL branch "OpenSSL_1_1_0-stable". 
- Since the last tested and verified working version is openssl 1.1.0, I'll suggest to git clone from OpenSSL_1_1_0-stable for maximum compatibility

Changes 2 - 
Modify README.md to git clone from openSSL branch "OpenSSL_1_1_0-stable". 
- Same reason as Changes 1

Changes 3 -
Modify Makefile to include -fcommon in the CFLAGS
- SInce GCC 10, it's defaults to -fno-common(instead of -fcommon) , which doesn't allow mulltiple declaration. This breaks the compilation of Revsh. To fix this, I'll suggest to include -fcommon in the CFLAGS.