### PR TITLE
Add connection status feedback for socks proxy connections.

### DIFF
--- a/common.h
+++ b/common.h
@@ -112,11 +112,13 @@
 #define CON_DORMANT 4
 
 /* Apparently reply strings for socks requests are static in the modern era. */
-#define SOCKS_V4_REPLY "\x00\x5a\x00\x00\x00\x00\x00\x00"
+#define SOCKS_V4_REPLY_OK "\x00\x5a\x00\x00\x00\x00\x00\x00"
+#define SOCKS_V4_REPLY_ERR "\x00\x5b\x00\x00\x00\x00\x00\x00"
 #define SOCKS_V4_REPLY_LEN 8
 #define SOCKS_V5_AUTH_REPLY "\x05\x00"
 #define SOCKS_V5_AUTH_REPLY_LEN 2
-#define SOCKS_V5_REPLY "\x05\x00\x00\x01\x00\x00\x00\x00\x00\x00"
+#define SOCKS_V5_REPLY_OK "\x05\x00\x00\x01\x00\x00\x00\x00\x00\x00"
+#define SOCKS_V5_REPLY_ERR "\x05\x01\x00\x01\x00\x00\x00\x00\x00\x00"
 #define SOCKS_V5_REPLY_LEN 10
 
 /* Maximum possible size of a socks request. */
@@ -203,6 +205,8 @@ int handle_message_dt_connection_ht_create_tun_tap();
 int handle_message_dt_connection_ht_response();
 int handle_connection_activate(struct connection_node *cur_connection_node);
 int handle_message_dt_connection_ht_active_dormant();
+int handle_message_dt_connection_ht_connected();
+int handle_message_dt_connection_ht_refused();
 int handle_message_dt_connection_ht_data();
 int handle_proxy_read(struct proxy_node *cur_proxy_node);
 int handle_connection_write(struct connection_node *cur_connection_node);
@@ -213,6 +217,8 @@ int handle_send_dt_proxy_ht_create(char *proxy_string, int proxy_type);
 int handle_send_dt_proxy_ht_report(struct proxy_node *cur_proxy_node);
 int handle_send_dt_connection_ht_destroy(unsigned short origin, unsigned short id, unsigned short header_errno);
 int handle_send_dt_connection_ht_create(struct connection_node *cur_connection_node);
+int handle_send_dt_connection_ht_connected(unsigned short origin, unsigned short id);
+int handle_send_dt_connection_ht_refused(unsigned short origin, unsigned short id);
 int handle_send_dt_nop();
 struct connection_node *handle_tun_tap_init(int ifr_flag);
 
@@ -253,6 +259,7 @@ struct connection_node *connection_node_create();
 void connection_node_delete(struct connection_node *);
 struct connection_node *connection_node_find(unsigned short origin, unsigned short id);
 void connection_node_queue(struct connection_node *cur_connection_node);
+void connection_node_socks_reply(struct connection_node *, int ok);
 int parse_socks_request(struct connection_node *cur_connection_node);
 char *addr_to_string(int atype, char *addr, char *port, int len);
 

--- a/protocol.h
+++ b/protocol.h
@@ -10,7 +10,7 @@
  */
 
 #define PROTOCOL_MAJOR_VERSION 1
-#define PROTOCOL_MINOR_VERSION 0
+#define PROTOCOL_MINOR_VERSION 1
 
 /**********************************************************************************************************************
  *
@@ -167,6 +167,8 @@
 // As such, this reporting is typically handled as a best effort without guarantee of delivery.
 #define DT_ERROR 6
 
+#define DT_CONNECTION_HT_CONNECTED 7
+#define DT_CONNECTION_HT_REFUSED 8
 /* 
  * Other protocol constants used in messaging.
  */

--- a/proxy.c
+++ b/proxy.c
@@ -419,7 +419,8 @@ struct connection_node *connection_node_create(){
  *
  * Outputs: None.
  *
- * Purpose: Initialize a new connection node, and put it into it's place in the linked list.
+ * Purpose: Report back to the socks client whether the requested connection
+ * request succeeded or not.
  *
  ******************************************************************************/
 void connection_node_socks_reply(struct connection_node *cur_connection_node, int ok){

--- a/proxy.c
+++ b/proxy.c
@@ -410,6 +410,40 @@ struct connection_node *connection_node_create(){
 	return(cur_connection_node);
 }
 
+/******************************************************************************
+ *
+ * connection_node_socks_reply()
+ *
+ * Inputs: A pointer to the connection_node and the socks reply type to send (0
+ * for error. 1 for ok).
+ *
+ * Outputs: None.
+ *
+ * Purpose: Initialize a new connection node, and put it into it's place in the linked list.
+ *
+ ******************************************************************************/
+void connection_node_socks_reply(struct connection_node *cur_connection_node, int ok){
+	char *reply_buff = NULL;
+	int reply_buff_len = 0;
+	if (cur_connection_node->socks_type == 4) {
+		if(ok) {
+			reply_buff = SOCKS_V4_REPLY_OK;
+		}
+		else {
+			reply_buff = SOCKS_V4_REPLY_ERR;
+		}
+		reply_buff_len = SOCKS_V4_REPLY_LEN;
+	} else if (cur_connection_node->socks_type == 5) {
+		if(ok) {
+			reply_buff = SOCKS_V5_REPLY_OK;
+		}
+		else {
+			reply_buff = SOCKS_V5_REPLY_ERR;
+		}
+		reply_buff_len = SOCKS_V5_REPLY_LEN;
+	}
+	write(cur_connection_node->fd, reply_buff, reply_buff_len);
+}
 
 /******************************************************************************
  *
@@ -555,6 +589,7 @@ int parse_socks_request(struct connection_node *cur_connection_node){
 
 	// Socks 4 or 4a.
 	if(head[index] == 4){
+		cur_connection_node->socks_type = 4;
 
 		/*
 		 * +----+----+----+----+----+----+----+----+----+----+....+----+
@@ -641,6 +676,7 @@ int parse_socks_request(struct connection_node *cur_connection_node){
 
 		// SOCKS 5
 	}else if(head[index] == 5){
+		cur_connection_node->socks_type = 5;
 
 		if(cur_connection_node->state == CON_SOCKS_INIT){
 			index += 1;


### PR DESCRIPTION
Adds feedbacks for socks proxy connections to explain if connection succeed or refuse. Ports now can be determined open/close for scanning using proxychains nmap -sT ...

This fixes bug where all ports are determined open when scanning.