### PR TITLE
Add outbound proxy support for target in connectback mode

### DIFF
--- a/common.h
+++ b/common.h
@@ -140,6 +140,13 @@
 #define ESCAPE_CR 1
 #define ESCAPE_TILDE 2
 
+/* Outbound proxy */
+#define OUTBOUND_PROXY_TYPE_NULL 0
+#define OUTBOUND_PROXY_TYPE_SOCKS4 1
+#define OUTBOUND_PROXY_TYPE_SOCKS4A 2
+#define OUTBOUND_PROXY_TYPE_SOCKS5 3
+#define OUTBOUND_PROXY_TYPE_SOCKS5H 4
+#define OUTBOUND_PROXY_TYPE_HTTP 5
 
 /******************************************************************************
  * global variables

--- a/common.h
+++ b/common.h
@@ -254,6 +254,7 @@ void connection_node_delete(struct connection_node *);
 struct connection_node *connection_node_find(unsigned short origin, unsigned short id);
 void connection_node_queue(struct connection_node *cur_connection_node);
 int parse_socks_request(struct connection_node *cur_connection_node);
+int parse_addr_string(char *addr_string, unsigned char ip[4], unsigned short *port);
 char *addr_to_string(int atype, char *addr, char *port, int len);
 
 /* report.c */

--- a/config.h
+++ b/config.h
@@ -15,23 +15,49 @@
  */
 
 // Default: no proxy
-//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_NULL
-//#define OUTBOUND_PROXY_ADDR NULL
+#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_NULL
+#define OUTBOUND_PROXY_ADDR NULL
+#define OUTBOUND_PROXY_USERNAME NULL
+#define OUTBOUND_PROXY_PASSWORD NULL
 
-// socks4 (CONTROL_ADDRESS must be ipv4 address)
-//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS4
+/* Examples */
 
-// socks4a (CONTROL_ADDRESS can be domain to be resolved by the proxy)
-//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS4A
+/* socks4 (CONTROL_ADDRESS must be ipv4 address) */
+// #define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS4
+// #define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+// #define OUTBOUND_PROXY_USERNAME NULL
+// #define OUTBOUND_PROXY_PASSWORD NULL
 
-// socks5 (CONTROL_ADDRESS must be ipv4 address)
-//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS5
+/* socks4a (CONTROL_ADDRESS can be domain to be resolved by the proxy) */
+// #define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS4A
+// #define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+// #define OUTBOUND_PROXY_USERNAME NULL
+// #define OUTBOUND_PROXY_PASSWORD NULL
 
-// socks5h (CONTROL_ADDRESS can be domain to be resolved by the proxy)
-//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS5H
+/* socks5 (CONTROL_ADDRESS must be ipv4 address) */
+// #define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS5
+// #define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+// #define OUTBOUND_PROXY_USERNAME NULL
+// #define OUTBOUND_PROXY_PASSWORD NULL
 
-// http (CONTROL_ADDRESS can be domain to be resolved by the proxy, control port must be allowed by proxy such as 443)
-//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_HTTP
+/* socks5h (CONTROL_ADDRESS can be domain to be resolved by the proxy) */
+// #define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS5H
+// #define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+// #define OUTBOUND_PROXY_USERNAME NULL
+// #define OUTBOUND_PROXY_PASSWORD NULL
+
+/* http (CONTROL_ADDRESS can be domain to be resolved by the proxy). Check proxy
+ * access control, for squid port 443 usually allowed */
+// #define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_HTTP
+// #define OUTBOUND_PROXY_ADDR "127.0.0.1:3128"
+// #define OUTBOUND_PROXY_USERNAME NULL
+// #define OUTBOUND_PROXY_PASSWORD NULL
+
+/* authentication (http proxy only) */
+// #define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_HTTP
+// #define OUTBOUND_PROXY_ADDR "127.0.0.1:3128"
+// #define OUTBOUND_PROXY_USERNAME "foo"
+// #define OUTBOUND_PROXY_PASSWORD "bar"
 
 // Default socks proxy listener port.
 #define SOCKS_LISTENER "2280"

--- a/config.h
+++ b/config.h
@@ -18,13 +18,17 @@
 #define OUTBOUND_PROXY_TYPE NULL
 #define OUTBOUND_PROXY_ADDR NULL
 
-// socks4
+// socks4 (CONTORL_ADDRESS must be ipv4 address)
 //#define OUTBOUND_PROXY_TYPE "socks4"
+//#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+
+// socks5 (CONTORL_ADDRESS must be ipv4 address)
+//#define OUTBOUND_PROXY_TYPE "socks5"
 //#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
 
 // socks5h
 //#define OUTBOUND_PROXY_TYPE "socks5h"
-//#define OUTBOUND_PROXY_ADDR "localhost:1080"
+//#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
 
 // http
 //#define OUTBOUND_PROXY_TYPE "http"

--- a/config.h
+++ b/config.h
@@ -15,28 +15,23 @@
  */
 
 // Default: no proxy
-#define OUTBOUND_PROXY_TYPE NULL
-#define OUTBOUND_PROXY_ADDR NULL
+//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_NULL
+//#define OUTBOUND_PROXY_ADDR NULL
 
-// socks4 (CONTORL_ADDRESS must be ipv4 address)
-//#define OUTBOUND_PROXY_TYPE "socks4"
-//#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+// socks4 (CONTROL_ADDRESS must be ipv4 address)
+//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS4
 
-// socks4a (CONTRL_ADDRESS can be domain to be resolved by the proxy)
-//#define OUTBOUND_PROXY_TYPE "socks4a"
-//#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+// socks4a (CONTROL_ADDRESS can be domain to be resolved by the proxy)
+//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS4A
 
-// socks5 (CONTORL_ADDRESS must be ipv4 address)
-//#define OUTBOUND_PROXY_TYPE "socks5"
-//#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+// socks5 (CONTROL_ADDRESS must be ipv4 address)
+//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS5
 
-// socks5h (CONTRL_ADDRESS can be domain to be resolved by the proxy)
-//#define OUTBOUND_PROXY_TYPE "socks5h"
-//#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+// socks5h (CONTROL_ADDRESS can be domain to be resolved by the proxy)
+//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_SOCKS5H
 
-// http (CONTRL_ADDRESS can be domain to be resolved by the proxy)
-//#define OUTBOUND_PROXY_TYPE "http"
-//#define OUTBOUND_PROXY_ADDR "127.0.0.1:3128"
+// http (CONTROL_ADDRESS can be domain to be resolved by the proxy, control port must be allowed by proxy such as 443)
+//#define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_HTTP
 
 // Default socks proxy listener port.
 #define SOCKS_LISTENER "2280"

--- a/config.h
+++ b/config.h
@@ -10,6 +10,26 @@
 #define CONTROL_ADDRESS "0.0.0.0"
 #define CONTROL_PORT "2200"
 
+/*
+ * Outbound proxy for target
+ */
+
+// Default: no proxy
+#define OUTBOUND_PROXY_TYPE NULL
+#define OUTBOUND_PROXY_ADDR NULL
+
+// socks4
+//#define OUTBOUND_PROXY_TYPE "socks4"
+//#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+
+// socks5h
+//#define OUTBOUND_PROXY_TYPE "socks5h"
+//#define OUTBOUND_PROXY_ADDR "localhost:1080"
+
+// http
+//#define OUTBOUND_PROXY_TYPE "http"
+//#define OUTBOUND_PROXY_ADDR "127.0.0.1:3128"
+
 // Default socks proxy listener port.
 #define SOCKS_LISTENER "2280"
 

--- a/config.h
+++ b/config.h
@@ -22,15 +22,19 @@
 //#define OUTBOUND_PROXY_TYPE "socks4"
 //#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
 
+// socks4a (CONTRL_ADDRESS can be domain to be resolved on target)
+//#define OUTBOUND_PROXY_TYPE "socks4a"
+//#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
+
 // socks5 (CONTORL_ADDRESS must be ipv4 address)
 //#define OUTBOUND_PROXY_TYPE "socks5"
 //#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
 
-// socks5h
+// socks5h (CONTRL_ADDRESS can be domain to be resolved on target)
 //#define OUTBOUND_PROXY_TYPE "socks5h"
 //#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
 
-// http
+// http (CONTRL_ADDRESS can be domain to be resolved on target)
 //#define OUTBOUND_PROXY_TYPE "http"
 //#define OUTBOUND_PROXY_ADDR "127.0.0.1:3128"
 

--- a/config.h
+++ b/config.h
@@ -22,7 +22,7 @@
 //#define OUTBOUND_PROXY_TYPE "socks4"
 //#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
 
-// socks4a (CONTRL_ADDRESS can be domain to be resolved on target)
+// socks4a (CONTRL_ADDRESS can be domain to be resolved by the proxy)
 //#define OUTBOUND_PROXY_TYPE "socks4a"
 //#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
 
@@ -30,11 +30,11 @@
 //#define OUTBOUND_PROXY_TYPE "socks5"
 //#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
 
-// socks5h (CONTRL_ADDRESS can be domain to be resolved on target)
+// socks5h (CONTRL_ADDRESS can be domain to be resolved by the proxy)
 //#define OUTBOUND_PROXY_TYPE "socks5h"
 //#define OUTBOUND_PROXY_ADDR "127.0.0.1:1080"
 
-// http (CONTRL_ADDRESS can be domain to be resolved on target)
+// http (CONTRL_ADDRESS can be domain to be resolved by the proxy)
 //#define OUTBOUND_PROXY_TYPE "http"
 //#define OUTBOUND_PROXY_ADDR "127.0.0.1:3128"
 

--- a/config.h
+++ b/config.h
@@ -53,7 +53,7 @@
 // #define OUTBOUND_PROXY_USERNAME NULL
 // #define OUTBOUND_PROXY_PASSWORD NULL
 
-/* authentication (http/socks5/socks5h proxy only) */
+/* proxy authentication (http/socks5/socks5h proxy only) */
 // #define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_HTTP
 // #define OUTBOUND_PROXY_ADDR "127.0.0.1:3128"
 // #define OUTBOUND_PROXY_USERNAME "foo"

--- a/config.h
+++ b/config.h
@@ -53,7 +53,7 @@
 // #define OUTBOUND_PROXY_USERNAME NULL
 // #define OUTBOUND_PROXY_PASSWORD NULL
 
-/* authentication (http proxy only) */
+/* authentication (http/socks5/socks5h proxy only) */
 // #define OUTBOUND_PROXY_TYPE OUTBOUND_PROXY_TYPE_HTTP
 // #define OUTBOUND_PROXY_ADDR "127.0.0.1:3128"
 // #define OUTBOUND_PROXY_USERNAME "foo"

--- a/helper_objects.h
+++ b/helper_objects.h
@@ -55,7 +55,7 @@ struct config_helper {
 	int tap;
 
 	char *ip_addr;
-	char *outbound_proxy_type;
+	int outbound_proxy_type;
 	char *outbound_proxy_addr;
 	char *keys_dir;
 	char *rc_file;

--- a/helper_objects.h
+++ b/helper_objects.h
@@ -57,6 +57,8 @@ struct config_helper {
 	char *ip_addr;
 	int outbound_proxy_type;
 	char *outbound_proxy_addr;
+	char *outbound_proxy_username;
+	char *outbound_proxy_password;
 	char *keys_dir;
 	char *rc_file;
 	char *shell;

--- a/helper_objects.h
+++ b/helper_objects.h
@@ -55,6 +55,8 @@ struct config_helper {
 	int tap;
 
 	char *ip_addr;
+	char *outbound_proxy_type;
+	char *outbound_proxy_addr;
 	char *keys_dir;
 	char *rc_file;
 	char *shell;

--- a/io_ssl.c
+++ b/io_ssl.c
@@ -1283,7 +1283,7 @@ int init_io_target(){
 				const char *HTTP_PROXY_HEADER_FMT = "Proxy-Authorization: basic %s\r\n";
 				char *http_proxy_header = calloc(1, strlen(HTTP_PROXY_HEADER_FMT) - 2 + strlen(credential_b64) + 1);
 				sprintf(http_proxy_header, HTTP_PROXY_HEADER_FMT, credential_b64);
-				free(credential);
+				free(credential_b64);
 
 				// Add proxy authorizationheader
 				http_connect_request = realloc(http_connect_request, strlen(http_connect_request) + strlen(http_proxy_header) + 1);

--- a/io_ssl.c
+++ b/io_ssl.c
@@ -1275,7 +1275,7 @@ int init_io_target(){
 				strcat(credential, username);
 				strcat(credential, ":");
 				strcat(credential, password);
-				char *credential_b64 = calloc(1, ((strlen(credential) / 3) * 4) + 1);
+				char *credential_b64 = calloc(1, (((strlen(credential) + 2) / 3) * 4) + 1);
 				EVP_EncodeBlock(credential_b64, credential, strlen(credential));
 				free(credential);
 

--- a/io_ssl.c
+++ b/io_ssl.c
@@ -1341,7 +1341,7 @@ int init_io_target(){
 				strcat(credential, ":");
 				strcat(credential, password);
 				char *credential_b64 = calloc(1, (((strlen(credential) + 2) / 3) * 4) + 1);
-				EVP_EncodeBlock(credential_b64, credential, strlen(credential));
+				EVP_EncodeBlock((unsigned char*) credential_b64, (unsigned char*) credential, strlen(credential));
 				free(credential);
 
 				// Build proxy authorization header

--- a/io_ssl.c
+++ b/io_ssl.c
@@ -1070,12 +1070,13 @@ int init_io_target(){
 				for(size_t j = 0; j < strlen(domain); j++) {
 					socks4a_connection_request[i++] = domain[j];
 				}
+				free(domain);
 
 				if(write(io->remote_fd, socks4a_connection_request, socks4a_connection_request_len) == -1) {
 					report_error("init_io_target(): write socks4a connection request (atyp 3): %s", strerror(errno));
+					free(socks4a_connection_request);
 					return(-1);
 				}
-				free(domain);
 				free(socks4a_connection_request);
 			}
 
@@ -1174,15 +1175,16 @@ int init_io_target(){
 				for(size_t j = 0; j < strlen(domain); j++) {
 					socks5_connection_request[i++] = domain[j];
 				}
+				free(domain);
 
 				socks5_connection_request[i++] = port >> 8;			// DST.PORT
 				socks5_connection_request[i++] = port & 0xff;		// DST.PORT
 
 				if(write(io->remote_fd, socks5_connection_request, socks5_connection_request_len) == -1) {
 					report_error("init_io_target(): write socks5 connection request (atyp 3): %s", strerror(errno));
+					free(socks5_connection_request);
 					return(-1);
 				}
-				free(domain);
 				free(socks5_connection_request);
 
 			}
@@ -1252,6 +1254,7 @@ int init_io_target(){
 			char *http_connect_request = calloc(1, strlen(http_connect_request_fmt) - 2 + strlen(config->ip_addr) + 1);
 			sprintf(http_connect_request, http_connect_request_fmt, config->ip_addr);
 			if(write(io->remote_fd, http_connect_request, strlen(http_connect_request)) == -1) {
+			    free(http_connect_request);
 				report_error("init_io_target(): write http connection request: %s", strerror(errno));
 				return(-1);
 			}

--- a/io_ssl.c
+++ b/io_ssl.c
@@ -1011,14 +1011,14 @@ int init_io_target(){
 	if(config->outbound_proxy_type && config->outbound_proxy_addr) {
 
 		// Outbound SOCKS4/SOCKS4A proxy
-		if(strcmp(config->outbound_proxy_type, "socks4") == 0 || strcmp(config->outbound_proxy_type, "socks4a") == 0) {
+		if(config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_SOCKS4 || config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_SOCKS4A) {
 
-			if(verbose) {
-				printf("Requesting %s connection to %s...", config->outbound_proxy_type, config->ip_addr);
-				fflush(stdout);
-			}
+			if(config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_SOCKS4) {
+				if(verbose) {
+					printf("Requesting socks4 connection to %s...", config->ip_addr);
+					fflush(stdout);
+				}
 
-			if(strcmp(config->outbound_proxy_type, "socks4") == 0) {
 				// Parse control ip and port from string
 				unsigned char ip[4] = {0};
 				unsigned short port = 0;
@@ -1043,7 +1043,12 @@ int init_io_target(){
 					report_error("init_io_target(): write socks4 request: %s", strerror(errno));
 					return(-1);
 				}
-			} else if(strcmp(config->outbound_proxy_type, "socks4a") == 0) {
+			} else if(config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_SOCKS4A) {
+				if(verbose) {
+					printf("Requesting socks4a connection to %s...", config->ip_addr);
+					fflush(stdout);
+				}
+
 				// Send socks4a connection request (domain)
 				char *domain = strdup(config->ip_addr);
 				char *p = strchr(domain, ':');
@@ -1097,11 +1102,16 @@ int init_io_target(){
 		}
 
 		// Outbound SOCKS5/SOCKS5H proxy
-		else if(strcmp(config->outbound_proxy_type, "socks5") == 0 || strcmp(config->outbound_proxy_type, "socks5h") == 0) {
+		else if(config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_SOCKS5 || config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_SOCKS5H) {
 
 			if(verbose) {
-				printf("Requesting %s connection to %s...", config->outbound_proxy_type, config->ip_addr);
-				fflush(stdout);
+				if(config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_SOCKS5) {
+					printf("Requesting socks5 connection to %s...", config->ip_addr);
+					fflush(stdout);
+				} else if(config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_SOCKS5H) {
+					printf("Requesting socks5h connection to %s...", config->ip_addr);
+					fflush(stdout);
+				}
 			}
 
 			// Send socks5 greeting (no authentication support)
@@ -1122,7 +1132,7 @@ int init_io_target(){
 				return(-1);
 			}
 
-			if (strcmp(config->outbound_proxy_type, "socks5") == 0) {
+			if (config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_SOCKS5) {
 
 				// Parse control ip and port from string
 				unsigned char ip[4] = {0};
@@ -1151,7 +1161,7 @@ int init_io_target(){
 					return(-1);
 				}
 
-			} else if(strcmp(config->outbound_proxy_type, "socks5h") == 0) {
+			} else if(config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_SOCKS5H) {
 
 				// Send socks5 connection request (domain)
 				char *domain = strdup(config->ip_addr);
@@ -1243,7 +1253,7 @@ int init_io_target(){
 		}
 
 		// Outbound HTTP proxy
-		else if(strcmp(config->outbound_proxy_type, "http") == 0) {
+		else if(config->outbound_proxy_type == OUTBOUND_PROXY_TYPE_HTTP) {
 			if(verbose) {
 				printf("Requesting http connection to %s...", config->ip_addr);
 				fflush(stdout);

--- a/io_ssl.c
+++ b/io_ssl.c
@@ -1066,6 +1066,7 @@ int init_io_target(){
 			char *domain = strdup(config->ip_addr);
 			char *p = strchr(domain, ':');
 			if (!p) {
+				free(domain);
 				return(-1);
 			}
 			*p = 0;
@@ -1088,6 +1089,8 @@ int init_io_target(){
 			socks5_connection_request[i++] = port & 0xff;		// DST.PORT
 
 			write(io->remote_fd, socks5_connection_request, socks5_connection_request_len);
+			free(domain);
+			free(socks5_connection_request);
 
 			// Receive initial part of socks5 response packet
 			char socks5_response_part1[4] = {0};
@@ -1141,6 +1144,7 @@ int init_io_target(){
 			char *http_connect_request = calloc(1, strlen(http_connect_request_fmt) - 2 + strlen(config->ip_addr) + 1);
 			sprintf(http_connect_request, http_connect_request_fmt, config->ip_addr);
 			write(io->remote_fd, http_connect_request, strlen(http_connect_request));
+			free(http_connect_request);
 
 			// Read http reponse header
 			char http_header[4096] = {0};

--- a/proxy.c
+++ b/proxy.c
@@ -783,6 +783,7 @@ int parse_addr_string(char *addr_string, unsigned char ip[4], unsigned short *po
 			char *tmp_buf = calloc(1, len);
 			memcpy(tmp_buf, s_start, len);
 			int n = atoi(tmp_buf);
+			free(tmp_buf);
 
 			if(parsed_elements < 4) {
 				ip[parsed_elements] = n;

--- a/proxy.c
+++ b/proxy.c
@@ -776,7 +776,7 @@ int parse_socks_request(struct connection_node *cur_connection_node){
  ******************************************************************************/
 int parse_addr_string(char *addr_string, unsigned char ip[4], unsigned short *port) {
 	int parsed_elements = 0;
-	int s_start = addr_string;
+	char *s_start = addr_string;
 	for(char *p = addr_string; ; p++) {
 		if(*p == '.' || *p == ':' || *p == '\x00') {
 			int len = p - s_start;

--- a/proxy.c
+++ b/proxy.c
@@ -763,6 +763,49 @@ int parse_socks_request(struct connection_node *cur_connection_node){
 
 /******************************************************************************
  *
+ * parse_addr_string()
+ *
+ * Inputs: Address string to parse.
+ *         Parsed ip.
+ *         Parsed port.
+ *
+ * Outputs: 1 on success, 0 otherwise.
+ *
+ * Purpose: Parse address string into ip and port.
+ *
+ ******************************************************************************/
+int parse_addr_string(char *addr_string, unsigned char ip[4], unsigned short *port) {
+	int parsed_elements = 0;
+	int s_start = addr_string;
+	for(char *p = addr_string; ; p++) {
+		if(*p == '.' || *p == ':' || *p == '\x00') {
+			int len = p - s_start;
+			char *tmp_buf = calloc(1, len);
+			memcpy(tmp_buf, s_start, len);
+			int n = atoi(tmp_buf);
+
+			if(parsed_elements < 4) {
+				ip[parsed_elements] = n;
+			} else {
+				*port = n;
+			}
+
+			parsed_elements++;
+			s_start = p+1;
+		}
+		if(*p == '\x00') {
+			break;
+		}
+	}
+	if(parsed_elements == 5) {
+		return(1);
+	}
+	return(0);
+}
+
+
+/******************************************************************************
+ *
  * addr_to_string()
  *
  * Inputs: The type of the socks request.

--- a/revsh.c
+++ b/revsh.c
@@ -311,6 +311,8 @@ int main(int argc, char **argv){
 	config->interactive = 1;
 	config->outbound_proxy_type = OUTBOUND_PROXY_TYPE;
 	config->outbound_proxy_addr = OUTBOUND_PROXY_ADDR;
+	config->outbound_proxy_username = OUTBOUND_PROXY_USERNAME;
+	config->outbound_proxy_password = OUTBOUND_PROXY_PASSWORD;
 	config->shell = NULL;
 	config->rc_file = RC_FILE;
 	config->keys_dir = KEYS_DIR;

--- a/revsh.c
+++ b/revsh.c
@@ -309,6 +309,8 @@ int main(int argc, char **argv){
 	io->escape_depth = 0;
 
 	config->interactive = 1;
+	config->outbound_proxy_type = OUTBOUND_PROXY_TYPE;
+	config->outbound_proxy_addr = OUTBOUND_PROXY_ADDR;
 	config->shell = NULL;
 	config->rc_file = RC_FILE;
 	config->keys_dir = KEYS_DIR;


### PR DESCRIPTION
Allows setting outbound proxy http, socks4, socks4a, socks5, socks5h. Code no perfect, please review.

Fixes #28 